### PR TITLE
Update buttons on main site for code-book link

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,12 +70,15 @@
                     <li>
                         <a href="https://github.com/QuantEcon/book-dp1/raw/main/dp.pdf" class="button fit"><img src="images/book.png" width="15"><span style="margin-left:10px">Book</span></a>
                     </li>
-                    <li>
+					<li>
+                        <a href="https://quantecon.github.io/book-dp1/intro.html" class="button fit"><img src="images/book.png" width="15"><span style="margin-left:10px">Code Book</span></a>
+                    </li>
+                    <!-- <li>
                         <a href="https://github.com/QuantEcon/book-dp1/tree/main/source_code_jl" class="button fit"><img src="images/julia.svg" width="15"><span style="margin-left:10px">Julia code</span></a>
                     </li>
                     <li>
                         <a href="https://github.com/QuantEcon/book-dp1/tree/main/source_code_py" class="button fit"><img src="images/python.png" width="15"><span style="margin-left:10px">Python code</span></a>
-                    </li>
+                    </li> -->
                     <li>
                         <a href="https://dp.quantecon.org/slides" class="button fit"><img src="images/slides.png" width="14"><span style="margin-left:10px">Slides</span></a>
                     </li>


### PR DESCRIPTION
@jstac this PR would update the two `Julia` and `python` links to be the combined link to the `code-book` that hosts both languages

<img width="1285" alt="Screenshot 2023-09-13 at 4 20 25 pm" src="https://github.com/QuantEcon/dp_text_website/assets/8263752/c48f967a-4369-400c-8c1b-1b174daa9dd6">
